### PR TITLE
ci: check PR titles are Conventional Commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,39 @@ on:
   pull_request:
 
 jobs:
+  # Squash merges put the PR title on main, and release-please reads that commit
+  # to decide the version. A title with no recognised prefix silently produces no
+  # release, so it is checked here rather than discovered after merging.
+  pr-title:
+    name: "PR title is a Conventional Commit"
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            deps
+            docs
+            refactor
+            test
+            ci
+            chore
+            build
+            revert
+          # A scope is optional, but if present it must be lowercase.
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter, so the
+            changelog reads consistently.
+
   ansible-lint:
     name: "Ansible - Lint"
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,12 @@ them and nobody edits the version by hand.
 A commit with no recognised prefix produces **no release at all**. That is
 deliberate - not every merge deserves a version - but it also means a genuine
 feature written as plain prose ships nothing. The prefix has to be on the commit
-that lands on main, which for a squashed PR is the **PR title**.
+that lands on main, which for a squashed PR is the **PR title**; CI validates it
+so the mistake surfaces before merging.
+
+Do not confuse these with the `feat/` and `fix/` **branch** prefixes this repo
+also uses. Branch names are a convention nothing parses; the colon form in the
+commit subject is what release-please reads. Both are in use and do not conflict.
 
 The flow: merge a `feat:`/`fix:` to main, and once CI is green release-please
 opens a release PR bumping `pyproject.toml` and writing `CHANGELOG.md`. Merging

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,7 +26,13 @@ How the version is decided:
 
 The prefix must be on the commit that lands on `main`. With squash merges that is
 the **PR title**, so a PR titled without a prefix ships nothing no matter what
-its individual commits said.
+its individual commits said. CI checks the PR title for this, so the mistake
+surfaces before the merge rather than after.
+
+Note that these colons are not the `feat/` and `fix/` **branch** prefixes this
+repo also uses. Branch names are a human convention that nothing parses; the
+colon form in the commit subject is what decides the version. Both are in use and
+they do not conflict.
 
 A commit that is not conventional produces no release. That is deliberate: not
 every merge deserves a version. Use `workflow_dispatch` on the Release workflow


### PR DESCRIPTION
Squash merges put the PR title on `main`, and release-please reads that commit to decide the version — so a title without a recognised prefix silently ships **no release**. That is only discoverable after merging.

This adds a pull-request-only check accepting the same types `release-please-config.json` declares, and requires a lowercase subject so changelog entries read consistently.

Also documents the distinction that prompted it: `feat/` and `fix/` **branch** prefixes are a human convention nothing parses, while `feat:`/`fix:` in the **commit subject** is what release-please reads. Both are in use and do not conflict.