### PR TITLE
fix: move the version line past the stray PyPI 1.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,6 +55,24 @@ itself, so a merge whose tests failed cannot be tagged and published. It also
 refreshes `uv.lock` inside the release PR, since that file records the project's
 own version while release-please rewrites only `pyproject.toml`.
 
+### Why the line starts at 1.0.1
+
+PyPI already held a manually published `1.0` from 2025-05-20 with no
+corresponding git tag, so it outranked everything the pipeline produced: `0.1.4`
+shipped correctly but PyPI still served `1.0` as the latest, and a plain
+`pip install otg-mcp` resolved to it. The version line was moved to `1.0.1` with a
+`Release-As: 1.0.1` commit footer so that every automated release from here is
+newer than anything already on PyPI.
+
+If you ever need to pin an exact version out of band, that same footer is the
+supported mechanism:
+
+```
+chore: cut a specific version
+
+Release-As: 1.2.3
+```
+
 ### Versions are plain semver now
 
 Earlier releases used PEP 440 pre-release strings (`0.1.3a0`, tagged `v0.1.3a`).


### PR DESCRIPTION
PyPI holds a manually published **`1.0`** from 2025-05-20 with no git tag, predating the automated pipeline. It outranks everything the pipeline produces — `0.1.4` published fine, but PyPI still serves `1.0` as latest and `pip install otg-mcp` resolves to it.

Merging this cuts **1.0.1** via a `Release-As: 1.0.1` footer on the squash commit, putting the version line ahead of that upload so every automated release from here is the newest thing on the index.

The jump is mechanical, not a stability claim: `1.0` already exists on PyPI, so anything below it is unreachable for consumers.

Confirmed it is your own upload, not a squat — identical project metadata (`Open Traffic Generator - Model Context Protocol`, author `OTG MCP Contributors`), uploaded 05:34 the same morning as the v0.1.2a release at 05:50.